### PR TITLE
Simplify `repository` property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "lint": "standard src/*.js lib/index.js scripts/*.js",
     "scripts": "node scripts/refresh.js && node scripts/build.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/watilde/karma-power-assert.git"
-  },
+  "repository": "watilde/karma-power-assert",
   "keywords": [
     "karma",
     "karma-plugin",


### PR DESCRIPTION
There's no need to write redundant information anymore, [npm does all of that](https://docs.npmjs.com/files/package.json#repository) :package:
