### PR TITLE
fix(package.json): replace the old org name with new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "standard src/*.js lib/index.js scripts/*.js",
     "scripts": "node scripts/refresh.js && node scripts/build.js"
   },
-  "repository": "watilde/karma-power-assert",
+  "repository": "power-assert-js/karma-power-assert",
   "keywords": [
     "karma",
     "karma-plugin",
@@ -43,8 +43,8 @@
     "power-assert": "^1.4.2"
   },
   "bugs": {
-    "url": "https://github.com/watilde/karma-power-assert/issues"
+    "url": "https://github.com/power-assert-js/karma-power-assert/issues"
   },
-  "homepage": "https://github.com/watilde/karma-power-assert#readme",
+  "homepage": "https://github.com/power-assert-js/karma-power-assert#readme",
   "license": "MIT"
 }


### PR DESCRIPTION
To perform the transfer to here new org, I've replaced the old name with new one. Once it's merged, I will publish it as `v1.0.0` since it's stable already.

Related issue:
+ https://github.com/power-assert-js/karma-power-assert/issues/10

cc @twada